### PR TITLE
remove import from svelte/internal

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,15 +27,15 @@
   "homepage": "https://github.com/jjagielka/svelte-pivottable#readme",
   "devDependencies": {
     "@sveltejs/adapter-static": "^1.0.6",
-    "@sveltejs/kit": "^1.5.5",
+    "@sveltejs/kit": "^1.20.4",
     "@sveltejs/package": "^1.0.2",
-    "svelte-check": "^3.0.3",
-    "typescript": "^4.9.5",
+    "svelte-check": "^3.4.3",
+    "typescript": "^5.0.0",
     "vite": "^4.1.1"
   },
   "type": "module",
   "dependencies": {
     "sortablejs": "^1.15.0",
-    "svelte": "^3.55.1"
+    "svelte": "^4.0.0"
   }
 }

--- a/src/lib/UI/DraggableAttribute.svelte
+++ b/src/lib/UI/DraggableAttribute.svelte
@@ -1,37 +1,43 @@
 <script>
-    import Draggable from "./Draggable.svelte";
-    import FilterBox from "./FilterBox.svelte";
-    import { is_empty } from "svelte/internal";
+  import Draggable from "./Draggable.svelte";
+  import FilterBox from "./FilterBox.svelte";
 
-    export let valueFilter;
-    export let name;
-    export let attrValues;
-    export let menuLimit;
-    export let updateValuesInFilter;
+  export let valueFilter;
+  export let name;
+  export let attrValues;
+  export let menuLimit;
+  export let updateValuesInFilter;
 
-    let open = false;
+  let open = false;
 
-    const toggleOpen = () => (open = !open);
+  $: is_empty = Object.keys(valueFilter).length === 0;
+
+  const toggleOpen = () => (open = !open);
 </script>
 
 <li data-id={name}>
-    <span class={`pvtAttr ${is_empty(valueFilter) ? "" : "pvtFilteredAttribute"}`}>
-        {name}
-        <span class="pvtTriangle" on:click={toggleOpen} on:keypress={toggleOpen}>
-            {" "}
-            ▾
-        </span>
+  <span class={`pvtAttr ${is_empty ? "" : "pvtFilteredAttribute"}`}>
+    {name}
+    <span class="pvtTriangle" on:click={toggleOpen} on:keypress={toggleOpen}>
+      {" "}
+      ▾
     </span>
+  </span>
 
-    {#if open}
-        <Draggable handle=".pvtDragHandle" close=".pvtCloseX" on:click={toggleOpen} on:close={toggleOpen}>
-            <FilterBox
-                {name}
-                {valueFilter}
-                values={attrValues}
-                {menuLimit}
-                on:change={(ev) => updateValuesInFilter(name, ev.detail)}
-            />
-        </Draggable>
-    {/if}
+  {#if open}
+    <Draggable
+      handle=".pvtDragHandle"
+      close=".pvtCloseX"
+      on:click={toggleOpen}
+      on:close={toggleOpen}
+    >
+      <FilterBox
+        {name}
+        {valueFilter}
+        values={attrValues}
+        {menuLimit}
+        on:change={(ev) => updateValuesInFilter(name, ev.detail)}
+      />
+    </Draggable>
+  {/if}
 </li>


### PR DESCRIPTION
Svelte 5 complains when importing from svelte/internal. This pull request removes the import so it should work in svelte 5.

For additional reference: https://github.com/sveltejs/svelte/blob/main/packages/svelte/src/internal/index.js

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request removes the import from 'svelte/internal' in the DraggableAttribute.svelte component to ensure compatibility with Svelte 5. The logic for checking if the valueFilter is empty has been updated to use a reactive statement.

- **Enhancements**:
    - Removed import from 'svelte/internal' to ensure compatibility with Svelte 5.

<!-- Generated by sourcery-ai[bot]: end summary -->