### PR TITLE
Remove Svelte Internal dependency to fix Svelte 5 compatibility.

### DIFF
--- a/src/lib/UI/DraggableAttribute.svelte
+++ b/src/lib/UI/DraggableAttribute.svelte
@@ -1,7 +1,6 @@
 <script>
     import Draggable from "./Draggable.svelte";
     import FilterBox from "./FilterBox.svelte";
-    import { is_empty } from "svelte/internal";
 
     export let valueFilter;
     export let name;
@@ -10,6 +9,10 @@
     export let updateValuesInFilter;
 
     let open = false;
+
+    function is_empty(obj) {
+        return Object.keys(obj).length === 0;
+    }
 
     const toggleOpen = () => (open = !open);
 </script>


### PR DESCRIPTION
This PR removes the use of Svelte internal functions which are disallowed in Svelte 5 and fixes the ability to use this plugin with new Svelte projects.

## Summary by Sourcery

Bug Fixes:
- Fix compatibility with Svelte 5 by removing the use of disallowed internal functions.